### PR TITLE
Added additional argument for function signature

### DIFF
--- a/test/swift_class_test.exs
+++ b/test/swift_class_test.exs
@@ -209,12 +209,10 @@ defmodule SwiftClassTest do
       output = [
         {
           ["red-header", {:_target, [], Elixir}],
-          {:__block__, [],
-            [
-              {:color, [], [{:., [], [nil, :red]}]},
-              {:font, [], [{:., [], [nil, :largeTitle]}]}
-            ]
-          }
+          [
+            {:color, [], [{:., [], [nil, :red]}]},
+            {:font, [], [{:., [], [nil, :largeTitle]}]}
+          ]
         }
       ]
 
@@ -232,13 +230,12 @@ defmodule SwiftClassTest do
 
       output = [
         {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]}, {:_target, [], Elixir}],
-         {:__block__, [],
           [
             {:foo, [], [true]},
             {:color, [], [{:color_name, [], Elixir}]},
             {:bar, [], [false]}
           ]
-        }}
+        }
       ]
 
       assert parse_class_block(input) == output
@@ -253,7 +250,7 @@ defmodule SwiftClassTest do
 
       output = [
         {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color, [], Elixir}]}, {:_target, [], Elixir}],
-           {:color, [], [{:color, [], Elixir}]}
+           [{:color, [], [{:color, [], Elixir}]}]
          }
       ]
 
@@ -275,14 +272,14 @@ defmodule SwiftClassTest do
 
       output = [
         {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]}, {:_target, [], Elixir}],
-         {:__block__, [], [
+         [
            {:foo, [], [true]},
            {:color, [], [{:color_name, [], Elixir}]},
            {:bar, [], [false]}
-         ]}},
+         ]},
         {
           ["color-red", {:_target, [], Elixir}],
-          {:color, [], [{:., [], [nil, :red]}]}
+          [{:color, [], [{:., [], [nil, :red]}]}]
         }
       ]
 
@@ -299,7 +296,7 @@ defmodule SwiftClassTest do
       output = [
         {
           ["color-red", [target: :watchos]],
-          {:color, [], [{:., [], [nil, :red]}]}
+          [{:color, [], [{:., [], [nil, :red]}]}]
         }
       ]
 

--- a/test/swift_class_test.exs
+++ b/test/swift_class_test.exs
@@ -209,10 +209,12 @@ defmodule SwiftClassTest do
       output = [
         {
           ["red-header", {:_target, [], Elixir}],
-          [
-            {:color, [], [{:., [], [nil, :red]}]},
-            {:font, [], [{:., [], [nil, :largeTitle]}]}
-          ]
+          {:__block__, [],
+            [
+              {:color, [], [{:., [], [nil, :red]}]},
+              {:font, [], [{:., [], [nil, :largeTitle]}]}
+            ]
+          }
         }
       ]
 
@@ -230,11 +232,13 @@ defmodule SwiftClassTest do
 
       output = [
         {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]}, {:_target, [], Elixir}],
-         [
-           {:foo, [], [true]},
-           {:color, [], [{Elixir, [], {:color_name, [], Elixir}}]},
-           {:bar, [], [false]}
-         ]}
+         {:__block__, [],
+          [
+            {:foo, [], [true]},
+            {:color, [], [{:color_name, [], Elixir}]},
+            {:bar, [], [false]}
+          ]
+        }}
       ]
 
       assert parse_class_block(input) == output
@@ -249,9 +253,8 @@ defmodule SwiftClassTest do
 
       output = [
         {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color, [], Elixir}]}, {:_target, [], Elixir}],
-         [
-           {:color, [], [{Elixir, [], {:color, [], Elixir}}]}
-         ]}
+           {:color, [], [{:color, [], Elixir}]}
+         }
       ]
 
       assert parse_class_block(input) == output
@@ -272,16 +275,14 @@ defmodule SwiftClassTest do
 
       output = [
         {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]}, {:_target, [], Elixir}],
-         [
+         {:__block__, [], [
            {:foo, [], [true]},
-           {:color, [], [{Elixir, [], {:color_name, [], Elixir}}]},
+           {:color, [], [{:color_name, [], Elixir}]},
            {:bar, [], [false]}
-         ]},
+         ]}},
         {
           ["color-red", {:_target, [], Elixir}],
-          [
-            {:color, [], [{:., [], [nil, :red]}]}
-          ]
+          {:color, [], [{:., [], [nil, :red]}]}
         }
       ]
 
@@ -298,9 +299,7 @@ defmodule SwiftClassTest do
       output = [
         {
           ["color-red", [target: :watchos]],
-          [
-            {:color, [], [{:., [], [nil, :red]}]}
-          ]
+          {:color, [], [{:., [], [nil, :red]}]}
         }
       ]
 

--- a/test/swift_class_test.exs
+++ b/test/swift_class_test.exs
@@ -208,7 +208,7 @@ defmodule SwiftClassTest do
 
       output = [
         {
-          "red-header",
+          ["red-header", [target: :all]],
           [
             {:color, [], [{:., [], [nil, :red]}]},
             {:font, [], [{:., [], [nil, :largeTitle]}]}
@@ -229,7 +229,7 @@ defmodule SwiftClassTest do
       """
 
       output = [
-        {{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]},
+        {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]}, [target: :all]],
          [
            {:foo, [], [true]},
            {:color, [], [{Elixir, [], {:color_name, [], Elixir}}]},
@@ -248,7 +248,7 @@ defmodule SwiftClassTest do
       """
 
       output = [
-        {{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color, [], Elixir}]},
+        {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color, [], Elixir}]}, [target: :all]],
          [
            {:color, [], [{Elixir, [], {:color, [], Elixir}}]}
          ]}
@@ -271,14 +271,33 @@ defmodule SwiftClassTest do
       """
 
       output = [
-        {{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]},
+        {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]}, [target: :all]],
          [
            {:foo, [], [true]},
            {:color, [], [{Elixir, [], {:color_name, [], Elixir}}]},
            {:bar, [], [false]}
          ]},
         {
-          "color-red",
+          ["color-red", [target: :all]],
+          [
+            {:color, [], [{:., [], [nil, :red]}]}
+          ]
+        }
+      ]
+
+      assert parse_class_block(input) == output
+    end
+
+    test "can take optional target in definition" do
+      input = """
+        "color-red", target: :watchos do
+          color(.red)
+        end
+      """
+
+      output = [
+        {
+          ["color-red", [target: :watchos]],
           [
             {:color, [], [{:., [], [nil, :red]}]}
           ]

--- a/test/swift_class_test.exs
+++ b/test/swift_class_test.exs
@@ -208,7 +208,7 @@ defmodule SwiftClassTest do
 
       output = [
         {
-          ["red-header", [target: :all]],
+          ["red-header", {:_target, [], Elixir}],
           [
             {:color, [], [{:., [], [nil, :red]}]},
             {:font, [], [{:., [], [nil, :largeTitle]}]}
@@ -229,7 +229,7 @@ defmodule SwiftClassTest do
       """
 
       output = [
-        {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]}, [target: :all]],
+        {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]}, {:_target, [], Elixir}],
          [
            {:foo, [], [true]},
            {:color, [], [{Elixir, [], {:color_name, [], Elixir}}]},
@@ -248,7 +248,7 @@ defmodule SwiftClassTest do
       """
 
       output = [
-        {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color, [], Elixir}]}, [target: :all]],
+        {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color, [], Elixir}]}, {:_target, [], Elixir}],
          [
            {:color, [], [{Elixir, [], {:color, [], Elixir}}]}
          ]}
@@ -271,14 +271,14 @@ defmodule SwiftClassTest do
       """
 
       output = [
-        {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]}, [target: :all]],
+        {[{:<>, [context: Elixir, imports: [{2, Kernel}]], ["color-", {:color_name, [], Elixir}]}, {:_target, [], Elixir}],
          [
            {:foo, [], [true]},
            {:color, [], [{Elixir, [], {:color_name, [], Elixir}}]},
            {:bar, [], [false]}
          ]},
         {
-          ["color-red", [target: :all]],
+          ["color-red", {:_target, [], Elixir}],
           [
             {:color, [], [{:., [], [nil, :red]}]}
           ]


### PR DESCRIPTION
The output functions will be `class/2` with the first argument being the class name and the second argument being the `target`.

So for the following:

```
"color-" <> color_name, target: :watchos do
  ...
end
```

we will generate:

```elixir
def class("color-" <> color_nae, target: :watchos) do
  ...
end
```

When no 2nd argument is given we default to `target: :all`

```
"color-" <> color_name do
   ...
end
```

will produce a function signature we can use to generate:

```elixir
def class("color-" <> color_name, target: :all) do
  ...
end
```